### PR TITLE
Don't reset day time / day counter

### DIFF
--- a/src/main/java/xyz/eclipseisoffline/customtimecycle/TimeManager.java
+++ b/src/main/java/xyz/eclipseisoffline/customtimecycle/TimeManager.java
@@ -118,7 +118,6 @@ public class TimeManager extends SavedData {
     }
 
     public static class DayPartTimeRate {
-        private static final long MAX_DAYTIME = 24000L;
         private final long duration;
         private final long incrementModulus;
         private final double increment;

--- a/src/main/java/xyz/eclipseisoffline/customtimecycle/TimeManager.java
+++ b/src/main/java/xyz/eclipseisoffline/customtimecycle/TimeManager.java
@@ -157,9 +157,6 @@ public class TimeManager extends SavedData {
             }
             if (level.getGameTime() % incrementModulus == 0) {
                 dayTime += increment;
-                if (dayTime > MAX_DAYTIME) {
-                    dayTime = 0L;
-                }
                 long newTime = Mth.lfloor(dayTime);
                 if (newTime != currentTime) {
                     level.setDayTime(newTime);


### PR DESCRIPTION
Resetting time causes issues for parts of the game and other mods that depend on the time continuously increasing, such as:
- game difficulty increasing over time
- moon phases, and more importantly mob spawning
- day counters that show the player how many in-game days have elapsed since they started playing
- `/time set` commands with a tick amount of over 24000

The only problem I can see with this (please correct me if I missed something) might be loss of precision over time. However, integers up to 9,007,199,254,740,992 can be exactly represented (when applied to ticks, that equals to more than 375,299,968,947 in-game days)

Alternatively, implement a persistent day counter in `TimeManager`, keep the time resetting code but with an added increment to the day counter, then add the counted days to the in-game time when it's being set.