### PR TITLE
fix: use correct fabric-permissions-api v0.3.1 for MC 1.21 & 1.21.1

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,7 +9,7 @@ minecraft-supported-fabric = ">=1.21 <=1.21.1"
 minecraft-supported-neoforge = "[1.21,1.21.1]"
 
 fabric-api = "0.116.6+1.21.1"
-fabric-permissions-api = "0.3.3"
+fabric-permissions-api = "0.3.1"
 fabric-modmenu = "11.0.3"
 
 neoforge = "21.1.209"


### PR DESCRIPTION
Fabric Permissions API 0.3.3 [causes a crash in MC 1.21 and 1.21.1](https://github.com/lucko/fabric-permissions-api/issues/29) and Lucko has since marked 0.3.1 as the correct version for MC 1.21 and 1.21.1 on their [Modrinth page](https://modrinth.com/mod/fabric-permissions-api/versions).